### PR TITLE
ci: Add nightly schedule and manual dispatch triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
       - 'releases/**'
+  schedule:
+    # Nightly build at 05:00 UTC (02:00 BRT).
+    - cron: '0 5 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}


### PR DESCRIPTION
Run the existing CI jobs every day at 05:00 UTC (02:00 BRT) to catch regressions caused by upstream drift in west.yml and the Nix flake between pushes. Also expose workflow_dispatch so a run can be triggered manually from the Actions tab.